### PR TITLE
Use the Rust's included LLVM linker

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,7 +5,9 @@
 # [target.x86_64-uwp-windows-msvc]
 # rustflags = ["-Ctarget-feature=+crt-static"]
 
-#[target.x86_64-pc-windows-msvc]
+[target.x86_64-pc-windows-msvc]
+linker = "rust-lld"
+
 [target.'cfg(all(windows, target_env = "msvc"))']
 rustflags = [
   # Set up delayloads.


### PR DESCRIPTION
Use the Rust's included LLVM linker instead of the MSVC linker.
The MSVC linker always link to kernel32.dll, but with the LLVM linker, it interprets link arguments differently so it can find the API set libs before kernel32.dll.