### PR TITLE
Avoid dependency on bcrypt.dll

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-/target
+target/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,166 @@
 version = 3
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "cc"
+version = "1.0.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24c3f4eff5495aee4c0399d7b6a0dc2b6e81be84242ffbfcf253ebacccc1d0cb"
+
+[[package]]
+name = "libc"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
+
+[[package]]
 name = "nativeps"
 version = "0.1.0"
+dependencies = [
+ "ansi_term",
+ "pal",
+ "terminal_size",
+]
+
+[[package]]
+name = "pal"
+version = "0.1.0"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "rustix"
+version = "0.35.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d51cc38aa10f6bbb377ed28197aa052aa4e2b762c22be9d3153d01822587e787"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8440c860cf79def6164e4a0a983bcc2305d82419177a0e0c71930d049e3ac5a1"
+dependencies = [
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+ansi_term = "0.12"
+terminal_size = "0.2.1"
+pal = { path = "./pal" }

--- a/pal/.gitignore
+++ b/pal/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+

--- a/pal/Cargo.toml
+++ b/pal/Cargo.toml
@@ -1,0 +1,9 @@
+# Copyright (C) Microsoft Corporation. All rights reserved.
+
+[package]
+name = "pal"
+version = "0.1.0"
+edition = "2021"
+
+[build-dependencies]
+cc = "1.0"

--- a/pal/build.rs
+++ b/pal/build.rs
@@ -1,0 +1,82 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+
+use std::env;
+use std::process::Command;
+use cc::windows_registry;
+
+// Environment variables used in this build file are documented at
+// https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts
+
+fn main() {
+    // Make import libs for API sets that are not in the SDK.
+    println!("cargo:rustc-link-search={}", env::var("OUT_DIR").unwrap());
+
+    for lib in [
+        "ext-ms-win-cng-rng-l1-1-0",
+    ] {
+        make_import_lib(lib);
+        println!("cargo:rustc-link-lib={}", lib);
+    }
+}
+
+// Gets the path to the tool for building '.lib' file from the environment variable, if it's set.
+fn get_tool_var(name: &str) -> Option<String> {
+    let target = env::var("TARGET").unwrap().replace('-', "_");
+    let var = format!("{}_{}", name, target);
+    println!("cargo:rerun-if-env-changed={}", var);
+    env::var(var)
+        .or_else(|_| {
+            println!("cargo:rerun-if-env-changed={}", name);
+            env::var(name)
+        }).ok()
+}
+
+fn make_import_lib(name: &str) {
+    println!("cargo:rerun-if-changed={}.def", name);
+
+    if let Some(dlltool) = get_tool_var("DLLTOOL") {
+        // This branch is for cross compilation from WSL2.
+        // When building from WSL2, the tool 'llvm-dlltool-11' will be used for producing the '.lib' file.
+        // For details, see https://microsoft.visualstudio.com/HyperVCloud/_git/hvlite?path=/ci/setup_windows_cross.sh&version=GBmain&line=47&lineEnd=69&lineStartColumn=1&lineEndColumn=2&lineStyle=plain&_a=contents
+        let mut dlltool = Command::new(dlltool);
+
+        let arch = match env::var("CARGO_CFG_TARGET_ARCH").unwrap().as_str() {
+            "x86" => "i386",
+            "x86_64" => "i386:x86-64",
+            "aarch64" => "arm64",
+            a => panic!("unsupported architecture {}", a),
+        };
+
+        dlltool.args(["-d", &format!("{}.def", name)]);
+        dlltool.args(["-m", arch]);
+        dlltool.args([
+            "-l",
+            &format!("{}/{}.lib", env::var("OUT_DIR").unwrap(), name),
+        ]);
+        if !dlltool.spawn().unwrap().wait().unwrap().success() {
+            panic!("dlltool failed");
+        }
+    } else {
+        // Find the 'lib.exe' from Visual Studio tools' location.
+        let mut lib = windows_registry::find(&env::var("TARGET").unwrap(), "lib.exe")
+            .expect("cannot find lib.exe");
+
+        let arch = match env::var("CARGO_CFG_TARGET_ARCH").unwrap().as_str() {
+            "x86" => "X86",
+            "x86_64" => "X64",
+            "aarch64" => "ARM64",
+            a => panic!("unsupported architecture {}", a),
+        };
+
+        lib.arg(format!("/machine:{}", arch));
+        lib.arg(format!("/def:{}.def", name));
+        lib.arg(format!(
+            "/out:{}/{}.lib",
+            env::var("OUT_DIR").unwrap(),
+            name
+        ));
+        if !lib.spawn().unwrap().wait().unwrap().success() {
+            panic!("lib.exe failed");
+        }
+    }
+}

--- a/pal/ext-ms-win-cng-rng-l1-1-0.def
+++ b/pal/ext-ms-win-cng-rng-l1-1-0.def
@@ -1,0 +1,4 @@
+LIBRARY ext-ms-win-cng-rng-l1-1-0
+
+EXPORTS
+    ProcessPrng

--- a/pal/src/lib.rs
+++ b/pal/src/lib.rs
@@ -1,0 +1,20 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+
+//! This crate provides a set of types that abstract over OS-specific platform
+//! primitives. It is focused on IO- and wait-related functionality: events,
+//! timers, and polling.
+//!
+//! As a convenience, it also exports some OS-specific functionality and some
+//! general library functionality.
+
+#[cfg(windows)]
+pub mod windows;
+
+#[cfg(windows)]
+use windows as sys;
+
+/// Writes cryptographically random bytes to `data` using the system RNG. Panics
+/// on error, since the system RNG should always be available.
+pub fn random(data: &mut [u8]) {
+    unsafe { sys::getrandom(data.as_mut_ptr(), data.len()) }
+}

--- a/pal/src/windows.rs
+++ b/pal/src/windows.rs
@@ -1,0 +1,17 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+
+#![cfg(windows)]
+
+//#[link(name = "ext-ms-win-cng-rng-l1-1-0")]
+extern "C" {
+    fn ProcessPrng(data: *mut u8, len: usize) -> u32;
+}
+
+/// # Safety
+///
+/// TODO
+pub unsafe fn getrandom(data: *mut u8, len: usize) {
+    if ProcessPrng(data, len) == 0 {
+        panic!("ProcessPrng failed");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,56 @@
+mod win_support;
+
+use ansi_term::enable_ansi_support;
+use terminal_size::{Width, Height, terminal_size};
+use std::env;
+use std::io::{BufReader, BufRead};
+use std::process::{Command, Stdio};
+
 fn main() {
-    println!("\x1b[93mHello, world!\x1b[0m");
+    let _ = enable_ansi_support();
+    let fg_yellow = "\x1b[93m";
+    let fg_red = "\x1b[31m";
+
+    if let Some((Width(w), Height(h))) = terminal_size() {
+        print_with_color(fg_yellow, &format!("term size: {} cols wide, {} lines high", w, h), true);
+    } else {
+        print_with_color(fg_yellow, "failed to get terminal size", true);
+    }
+
+    print_with_color(fg_yellow, "Hello, world!", true);
+
+    let args: Vec<String> = env::args().collect();
+    print_with_color(fg_yellow, &format!("{:?}", args), true);
+    if args.len() > 1 {
+        let mut process = Command::new(&args[1]);
+        process.stdout(Stdio::piped());
+
+        match process.spawn() {
+            Ok(mut child) => {
+                let mut buf_read = BufReader::new(child.stdout.take().unwrap());
+                let mut line = String::new();
+
+                loop {
+                    let len = buf_read.read_line(&mut line).unwrap();
+                    if len == 0 { break; } // EOF
+                    print_with_color(fg_yellow, &line, false);
+                    line.clear();
+                }
+
+                let _ = child.wait();
+            }
+
+            Err(err) => {
+                print_with_color(fg_red, &format!("Failed to start process: {}", err), true);
+            }
+        }
+    }
+}
+
+fn print_with_color(fg_color: &str, text: &str, new_line: bool) {
+    if new_line {
+        println!("{}{}\x1b[0m", fg_color, text);
+    } else {
+        print!("{}{}\x1b[0m", fg_color, text);
+    }
 }

--- a/src/win_support.rs
+++ b/src/win_support.rs
@@ -1,0 +1,72 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+
+#![cfg(windows)]
+
+/// Makes a byte slice from a pointer and length, where the pointer may be null.
+///
+/// # Safety
+///
+/// The caller must ensure `data..data+len` is a valid mutable memory region.
+unsafe fn c_slice<'a>(data: *mut u8, len: u32) -> &'a mut [u8] {
+    if len == 0 {
+        // Special case this since `data` may be null in this case, which is
+        // prohibited by `from_raw_parts_mut`.
+        &mut []
+    } else {
+        // SAFETY: the caller guarantees that `data..data + len` is valid.
+        std::slice::from_raw_parts_mut(data, len as usize)
+    }
+}
+
+/// Rust calls RtlGenRandom (also known as SystemFunction036) as part of hashmap
+/// initialization. Redirect this to the CRNG of our choice to avoid a dependency
+/// on advapi32.dll.
+///
+/// # Safety
+///
+/// - `data` must point to a buffer at least `len` bytes in size.
+#[no_mangle]
+pub unsafe extern "system" fn SystemFunction036(data: *mut u8, len: u32) -> u8 {
+    // SAFETY: the caller guarantees that `data..data + len` is valid.
+    let data = c_slice(data, len);
+    pal::random(data);
+    1
+}
+
+/// If a call to SystemFunction036 is marked as a dllimport, then it may be an indirect call
+/// through __imp_SystemFunction036 instead.
+#[no_mangle]
+pub static __imp_SystemFunction036: unsafe extern "system" fn(*mut u8, u32) -> u8 =
+    SystemFunction036;
+
+/// Rust calls BCryptGenRandom as part of hashmap initialization. Redirect this
+/// to the CRNG of our choice to avoid a dependency on bcrypt.dll.
+///
+/// # Safety
+///
+/// - `data` must point to a buffer at least `len` bytes in size.
+#[no_mangle]
+pub unsafe extern "system" fn BCryptGenRandom(
+    algorithm: usize,
+    data: *mut u8,
+    len: u32,
+    flags: u32,
+) -> u32 {
+    const BCRYPT_RNG_USE_ENTROPY_IN_BUFFER: u32 = 1; // ignored in Win8+
+    const BCRYPT_USE_SYSTEM_PREFERRED_RNG: u32 = 2;
+    if algorithm != 0
+        || flags & !BCRYPT_RNG_USE_ENTROPY_IN_BUFFER != BCRYPT_USE_SYSTEM_PREFERRED_RNG
+    {
+        unimplemented!("unsupported options passed to BCryptGenRandom");
+    }
+    // SAFETY: the caller guarantees that `data..data + len` is valid.
+    let data = c_slice(data, len);
+    pal::random(data);
+    0
+}
+
+/// If a call to BCryptGenRandom is marked as a dllimport, then it may be an indirect call
+/// through __imp_BCryptGenRandom instead.
+#[no_mangle]
+pub static __imp_BCryptGenRandom: unsafe extern "system" fn(usize, *mut u8, u32, u32) -> u32 =
+    BCryptGenRandom;


### PR DESCRIPTION
Redirect system calls to `RtlGenRandom` and `BCryptGenRandom` to `ProcessPrng`.